### PR TITLE
Replace HTTParty with Typhoeus

### DIFF
--- a/iap-validator.gemspec
+++ b/iap-validator.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |s|
   s.executables   = `git ls-files -- bin/*`.split("\n").map{ |f| File.basename(f) }
   s.require_paths = ["lib"]
 
-  s.add_dependency "httparty"
+  s.add_dependency "typhoeus"
   s.add_dependency "multi_json"
 
   s.add_development_dependency 'rspec'

--- a/lib/iap-validator.rb
+++ b/lib/iap-validator.rb
@@ -5,15 +5,15 @@ require 'typhoeus'
 
 module IAPValidator
   class IAPValidator
-    SANDBOX_URL = 'https://sandbox.itunes.apple.com'.freeze
-    PRODUCTION_URL = 'https://buy.itunes.apple.com'.freeze
+    SANDBOX_URL = 'https://sandbox.itunes.apple.com/verifyReceipt'.freeze
+    PRODUCTION_URL = 'https://buy.itunes.apple.com/verifyReceipt'.freeze
 
     HEADERS = {
       'Content-Type': 'application/json'
     }.freeze
 
     def self.validate(data, sandbox = false, password = nil)
-      base_uri = sandbox ? SANDBOX_URL : PRODUCTION_URL
+      url = sandbox ? SANDBOX_URL : PRODUCTION_URL
 
       json = if password.nil?
                 { 'receipt-data' => data }
@@ -21,9 +21,7 @@ module IAPValidator
                 { 'receipt-data' => data, 'password' => password }
              end
 
-      uri = URI.join(base_uri, '/verifyReceipt')
-
-      resp = Typhoeus.post(uri, body: MultiJson.encode(json), headers: HEADERS)
+      resp = Typhoeus.post(url, body: MultiJson.encode(json), headers: HEADERS)
 
       return nil unless resp.code == 200
 

--- a/spec/iap-validator_spec.rb
+++ b/spec/iap-validator_spec.rb
@@ -1,15 +1,14 @@
 require 'helper'
 
 RSpec.describe IAPValidator::IAPValidator do
-
   it 'should validate' do
     receipt_data = 'randomreceiptdata'
-    expected_response = { "cool" => 123 }
+    expected_response = { 'cool' => 123 }
     expected_response_str = MultiJson.dump(expected_response)
 
-    stub = stub_request(:post, IAPValidator::IAPValidator::SANDBOX_URL + '/verifyReceipt').
-        with(body: { 'receipt-data' => receipt_data }).
-        and_return(status: 200, body: expected_response_str)
+    stub = stub_request(:post, IAPValidator::IAPValidator::SANDBOX_URL + '/verifyReceipt')
+           .with(body: { 'receipt-data' => receipt_data })
+           .and_return(status: 200, body: expected_response_str)
 
     resp = IAPValidator::IAPValidator.validate(receipt_data, true)
 
@@ -19,17 +18,16 @@ RSpec.describe IAPValidator::IAPValidator do
 
   it 'should validate with error' do
     receipt_data = 'randomreceiptdata'
-    expected_response = { "cool" => 123 }
+    expected_response = { 'cool' => 123 }
     expected_response_str = MultiJson.dump(expected_response)
 
-    stub = stub_request(:post, IAPValidator::IAPValidator::SANDBOX_URL + '/verifyReceipt').
-        with(body: { 'receipt-data' => receipt_data }).
-        and_return(status: 400, body: expected_response_str)
+    stub = stub_request(:post, IAPValidator::IAPValidator::SANDBOX_URL + '/verifyReceipt')
+           .with(body: { 'receipt-data' => receipt_data })
+           .and_return(status: 400, body: expected_response_str)
 
     resp = IAPValidator::IAPValidator.validate(receipt_data, true)
 
     expect(stub).to have_been_requested
     expect(resp).to be_nil
   end
-
 end

--- a/spec/iap-validator_spec.rb
+++ b/spec/iap-validator_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe IAPValidator::IAPValidator do
     expected_response = { 'cool' => 123 }
     expected_response_str = MultiJson.dump(expected_response)
 
-    stub = stub_request(:post, IAPValidator::IAPValidator::SANDBOX_URL + '/verifyReceipt')
+    stub = stub_request(:post, IAPValidator::IAPValidator::SANDBOX_URL)
            .with(body: { 'receipt-data' => receipt_data })
            .and_return(status: 200, body: expected_response_str)
 
@@ -21,7 +21,7 @@ RSpec.describe IAPValidator::IAPValidator do
     expected_response = { 'cool' => 123 }
     expected_response_str = MultiJson.dump(expected_response)
 
-    stub = stub_request(:post, IAPValidator::IAPValidator::SANDBOX_URL + '/verifyReceipt')
+    stub = stub_request(:post, IAPValidator::IAPValidator::SANDBOX_URL)
            .with(body: { 'receipt-data' => receipt_data })
            .and_return(status: 400, body: expected_response_str)
 


### PR DESCRIPTION
We want to replace HTTParty with Typhoeus for the following reasons:

1) The old HTTParty implementation was not thread-safe (and HTTParty thread safety is not a guarantee) as a class variable shared across many threads could be modified at any time.
2) We want to standardize on use of Typhoeus for HTTP